### PR TITLE
Changed plugin id to npm published name.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="io.phasr.cordova.plugin.itunesfilesharing"
+        id="cordova-plugin-itunesfilesharing"
         version="0.0.1">
 
     <name>cordova-plugin-itunesfilesharing</name>


### PR DESCRIPTION
I changed the plugin id because cordova will try to download it  again when you do prepare if the id doesn't match the npm package name.
This prevents building the app without internet access which can be a very big inconvenience.
Obviously even if this is merged, you'll have to republish on npm.